### PR TITLE
Combine QUERY and QUALIFIERS arguments together

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install gh-search
 
 ## Usage
 
-**IMPORTANT**: This tool requires that you GitHub token set on the `GITHUB_TOKEN` envar (or passed to the script via the `--github-token` option).
+**IMPORTANT**: This tool requires that you GitHub token set on the `GITHUB_TOKEN` envvar (or passed to the script via the `--github-token` option).
 
 Invoke with `gh-search` and pass a query string as the first argument. For example, to search for the string "usage" in this repo:
 ```bash
@@ -35,7 +35,7 @@ _Note that `repo:` is a search qualifier natively supported by the GitHub Search
 
 ### Enterprise
 
-If you want to search against GitHub Enterprise set the `GITHUB_API_URL` envar with a URL to the v3 api endpoint. eg. `GITHUB_API_URL=https://git.mycompany.net/api/v3`. You can also use the `--github-api-url` option for this.
+If you want to search against GitHub Enterprise set the `GITHUB_API_URL` envvar with a URL to the v3 api endpoint. eg. `GITHUB_API_URL=https://git.mycompany.net/api/v3`. You can also use the `--github-api-url` option for this.
 
 ## Developing
 

--- a/ghsearch/gh_search.py
+++ b/ghsearch/gh_search.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Callable, Dict, Iterable, List
+from typing import Callable, Dict, List
 
 import click
 import github
@@ -14,8 +14,8 @@ class GHSearch:
         self.filters = filters
         self.verbose = verbose
 
-    def get_filtered_results(self, query: str, qualifiers: Iterable) -> Dict[str, List[ContentFile]]:
-        results = self.client.search_code(query=" ".join([query, *qualifiers]))
+    def get_filtered_results(self, query: List[str]) -> Dict[str, List[ContentFile]]:
+        results = self.client.search_code(query=" ".join(query))
         repos = defaultdict(list)
 
         with ProgressPrinter(overwrite=not self.verbose) as printer:

--- a/ghsearch/main.py
+++ b/ghsearch/main.py
@@ -80,10 +80,7 @@ def _create_none_value_validator(message):
     return _validator
 
 
-@click.command(
-    help="[QUERY] can contain search qualifiers, for example 'lookingforthis repo:janeklb/gh-search'",
-    context_settings={"max_content_width": 120},
-)
+@click.command(context_settings={"max_content_width": 120})
 @click.argument("query")
 @click.argument("qualifiers", nargs=-1)
 @click.option(

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -44,21 +44,21 @@ def mock_progress_printer():
 
 def test_get_filtered_results_calls_search_code_correctly(mock_client):
     ghsearch = GHSearch(mock_client, [])
-    ghsearch.get_filtered_results("name", ["org:janeklb", "filename:setup.py"])
+    ghsearch.get_filtered_results(["name", "org:janeklb", "filename:setup.py"])
 
     mock_client.search_code.assert_called_once_with(query="name org:janeklb filename:setup.py")
 
 
 def test_get_filtered_results_without_filters(mock_client, mock_result_1, mock_result_2, mock_result_3):
     ghsearch = GHSearch(mock_client, [])
-    repos = ghsearch.get_filtered_results("stub", ["org:stub"])
+    repos = ghsearch.get_filtered_results(["query", "org:bort"])
 
     assert repos == {"org/repo1": [mock_result_1, mock_result_2], "org/repo2": [mock_result_3]}
 
 
 def test_get_filtered_results_with_filters(mock_client, mock_result_1, mock_result_2, mock_result_3):
     ghsearch = GHSearch(mock_client, [lambda x: x.path != "2.txt"])
-    repos = ghsearch.get_filtered_results("stub", ["org:stub"])
+    repos = ghsearch.get_filtered_results(["query", "org:bort"])
 
     assert repos == {"org/repo1": [mock_result_1], "org/repo2": [mock_result_3]}
 
@@ -69,7 +69,7 @@ def test_get_filtered_results_verbose(mock_client, mock_result_1, mock_result_2,
 
     ghsearch = GHSearch(mock_client, [filter_fn], verbose=True)
 
-    repos = ghsearch.get_filtered_results("stub", ["org:stub"])
+    repos = ghsearch.get_filtered_results(["query", "org:bort"])
 
     assert repos == {
         "org/repo1": [mock_result_1, mock_result_2],

--- a/tests/unit/main_test.py
+++ b/tests/unit/main_test.py
@@ -35,7 +35,7 @@ def mock_build_client(mock_github):
 
 
 def test_run(assert_click_echo_calls):
-    run("query", [], "token")
+    run(["query"], "token")
     assert_click_echo_calls(
         call("Results:"),
         call(" 2 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query"),
@@ -45,7 +45,7 @@ def test_run(assert_click_echo_calls):
 
 
 def test_run_with_qualifiers(assert_click_echo_calls):
-    run("query", ["org:foo", "filename:bar"], "token")
+    run(["query", "org:foo", "filename:bar"], "token")
     assert_click_echo_calls(
         call("Results:"),
         call(" 2 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query%20filename%3Abar"),
@@ -56,12 +56,12 @@ def test_run_with_qualifiers(assert_click_echo_calls):
 
 def test_run_bad_credentials(assert_click_echo_calls, mock_github):
     mock_github.search_code.side_effect = BadCredentialsException(404, "No!")
-    run("query", [], "bad-credentials")
+    run(["query"], "bad-credentials")
     assert_click_echo_calls(call('Bad Credentials: 404 "No!"\n\nrun gh-search --help', err=True))
 
 
 def test_run_verbose(assert_click_echo_calls):
-    run("query", [], "token", verbose=True)
+    run(["query"], "token", verbose=True)
     assert_click_echo_calls(
         call("Starting with GH Rate limit: 10"),
         call("Skipping result for org/repo2 via not_archived_filter"),
@@ -74,7 +74,7 @@ def test_run_verbose(assert_click_echo_calls):
 
 
 def test_run_include_archived(assert_click_echo_calls):
-    run("query", [], "token", include_archived=True)
+    run(["query"], "token", include_archived=True)
     assert_click_echo_calls(
         call("Results:"),
         call(" 2 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query"),
@@ -86,7 +86,7 @@ def test_run_include_archived(assert_click_echo_calls):
 
 
 def test_run_content_filter(assert_click_echo_calls):
-    run("query", [], "token", content_filter="special content")
+    run(["query"], "token", content_filter="special content")
     assert_click_echo_calls(
         call("Results:"),
         call(" 1 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query"),
@@ -95,7 +95,7 @@ def test_run_content_filter(assert_click_echo_calls):
 
 
 def test_run_path_filter(assert_click_echo_calls):
-    run("query", [], "token", path_filter="file.txt")
+    run(["query"], "token", path_filter="file.txt")
     assert_click_echo_calls(
         call("Results:"),
         call(" 1 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query"),


### PR DESCRIPTION
Having `QUERY` and `QUALIFIERS` separate isn't quite correct because you can have multiple search terms (and with `QUERY` it suggests you're only allowed one)