### PR TITLE
Nicer output

### DIFF
--- a/ghsearch/main.py
+++ b/ghsearch/main.py
@@ -15,6 +15,9 @@ def _sanitize_qualifiers_for_search_url(query: List[str]) -> List[str]:
 
 
 def _print_results(query: List[str], results: Dict[str, List[ContentFile]]) -> None:
+    if len(results) == 0:
+        click.echo("No results!")
+        return
     sorted_results = sorted(results.items(), key=lambda kv: len(kv[1]), reverse=True)
 
     q_param = parse.quote(" ".join(_sanitize_qualifiers_for_search_url(query)))

--- a/ghsearch/terminal.py
+++ b/ghsearch/terminal.py
@@ -33,7 +33,7 @@ class ProgressPrinter(contextlib.AbstractContextManager):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.overwrite:
             self._overwrite_previous_line()
-            click.echo("\r" + SHOW_CURSOR)
+            click.echo("\r" + SHOW_CURSOR, nl=False)
         return None
 
     def _overwrite_previous_line(self, message=""):

--- a/tests/unit/main_test.py
+++ b/tests/unit/main_test.py
@@ -101,3 +101,9 @@ def test_run_path_filter(assert_click_echo_calls):
         call(" 1 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query"),
         call("\t- file.txt"),
     )
+
+
+def test_run_no_results(assert_click_echo_calls, mock_github):
+    mock_github.search_code.return_value = []
+    run(["query"], "token")
+    assert_click_echo_calls(call("No results!"))

--- a/tests/unit/terminal_test.py
+++ b/tests/unit/terminal_test.py
@@ -11,7 +11,7 @@ def test_progress_printer(assert_click_echo_calls):
     assert_click_echo_calls(
         call("\r\033[?25lHello!", nl=False),
         call("\r\033[?25l      ", nl=False),
-        call("\r\033[?25h"),
+        call("\r\033[?25h", nl=False),
     )
 
 


### PR DESCRIPTION
- cccfccf prevent blank newline from appearing before results are printed
- 04d6003 show a 'no results' message