### PR TITLE
Check core api rate limit (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ GitHub code search from your cli
 
 ## Features
 
-* All features of [GitHub Search API](https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-code) (eg. search qualifiers)
+* Uses [GitHub Search API](https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-code)
 * Apply filters on the GitHub Search API response (eg. ignore archived repos or search for additional text in matched content)
 * View search results grouped by repo
+* Core API rate limit check (prevent accidentally consuming your entire core api quota) 
 * Works with GitHub Enterprise
 
 ## Installation

--- a/ghsearch/filters.py
+++ b/ghsearch/filters.py
@@ -2,6 +2,10 @@ from github.ContentFile import ContentFile
 
 
 class Filter:
+    """This filter uses the core api"""
+
+    uses_core_api = True
+
     def __call__(self, result: ContentFile) -> bool:
         raise NotImplementedError
 
@@ -21,6 +25,7 @@ class NotArchivedFilter(Filter):
 
 class PathFilter(Filter):
     def __init__(self, path_filter: str):
+        self.uses_core_api = False
         self.path_filter = path_filter
 
     def __call__(self, result: ContentFile) -> bool:

--- a/ghsearch/gh_search.py
+++ b/ghsearch/gh_search.py
@@ -4,10 +4,21 @@ from typing import Dict, List
 import click
 import github
 from github.ContentFile import ContentFile
+from github.Rate import Rate
 from github.RateLimit import RateLimit
 
 from ghsearch.filters import Filter
 from ghsearch.terminal import ProgressPrinter
+
+CORE_LIMIT_THRESHOLD = 0.1
+CORE_LIMIT_WARNING_MESSAGE = """
+Warning: you are at risk of using more than the remaining {threshold:.0%} of your core api limit.
+Your search yielded {num} results, and each result may trigger up to {calls_per_res} core api call(s) per result.
+
+Your current usage is {remaining}/{limit} (resets at {reset})
+
+Do you want to continue?
+"""
 
 
 def _echo_rate_limits(rate_limit: RateLimit) -> None:
@@ -30,8 +41,9 @@ class GHSearch:
             _echo_rate_limits(rate_limit)
 
         results = self.client.search_code(query=" ".join(query))
-        repos = defaultdict(list)
+        self._check_core_limit_threshold(results.totalCount, rate_limit.core)
 
+        repos = defaultdict(list)
         with ProgressPrinter(overwrite=not self.verbose) as printer:
             for result in results:
                 printer(f"Checking result for {result.repository.full_name}")
@@ -51,3 +63,21 @@ class GHSearch:
             if not result_filter(result):
                 return result_filter.__class__.__name__
         return False
+
+    def _check_core_limit_threshold(self, num_results: int, core_rate: Rate) -> None:
+        max_core_api_calls_per_result = sum(bool(f.uses_core_api) for f in self.filters)
+        if max_core_api_calls_per_result > 0:
+
+            remaining_worst_case = core_rate.remaining - (num_results * max_core_api_calls_per_result)
+            if remaining_worst_case / core_rate.limit < CORE_LIMIT_THRESHOLD:
+                click.confirm(
+                    CORE_LIMIT_WARNING_MESSAGE.format(
+                        threshold=CORE_LIMIT_THRESHOLD,
+                        reset=core_rate.reset,
+                        limit=core_rate.limit,
+                        remaining=core_rate.remaining,
+                        num=num_results,
+                        calls_per_res=max_core_api_calls_per_result,
+                    ).strip(),
+                    abort=True,
+                )

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,6 +1,22 @@
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from github.ContentFile import ContentFile
+
+
+class MockPaginatedList:
+    def __init__(self, *items):
+        self.items = items
+        self.totalCount = len(items)
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+class MockRateLimit:
+    def __init__(self, core_remaining, core_limit, core_reset, search_remaining, search_limit, search_reset):
+        self.core = SimpleNamespace(remaining=core_remaining, limit=core_limit, reset=core_reset)
+        self.search = SimpleNamespace(remaining=search_remaining, limit=search_limit, reset=search_reset)
 
 
 def build_mock_result(repo_full_name: str, path: str, archived: bool = False, decoded_content: bytes = b""):

--- a/tests/unit/filters_test.py
+++ b/tests/unit/filters_test.py
@@ -25,6 +25,7 @@ def test_build_path_filter(path_matcher, path, expected_result, mock_content_fil
     mock_content_file.path = path
 
     assert path_filter(mock_content_file) is expected_result
+    assert path_filter.uses_core_api is False
 
 
 @pytest.mark.parametrize(
@@ -39,6 +40,7 @@ def test_build_content_filter(content_matcher, content_bytes, expected_result, m
     mock_content_file.decoded_content = content_bytes
 
     assert content_filter(mock_content_file) is expected_result
+    assert content_filter.uses_core_api is True
 
 
 @pytest.mark.parametrize(
@@ -53,3 +55,4 @@ def test_build_not_archived_filter(archived, expected_result, mock_content_file)
     mock_content_file.repository.archived = archived
 
     assert not_archived_filter(mock_content_file) is expected_result
+    assert not_archived_filter.uses_core_api is True

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace as StubObject
 from unittest.mock import Mock, patch
 
 import github
@@ -6,7 +5,7 @@ import pytest
 
 from ghsearch.gh_search import GHSearch
 
-from . import build_mock_result
+from . import MockPaginatedList, MockRateLimit, build_mock_result
 
 
 @pytest.fixture
@@ -27,10 +26,8 @@ def mock_result_3():
 @pytest.fixture
 def mock_client(mock_result_1, mock_result_2, mock_result_3):
     mock = Mock(spec=github.Github)
-    mock.search_code.return_value = [mock_result_1, mock_result_2, mock_result_3]
-    mock.get_rate_limit.return_value = StubObject(
-        search=StubObject(remaining=10, limit=10, reset="now"), core=StubObject(remaining=10, limit=10, reset="now")
-    )
+    mock.search_code.return_value = MockPaginatedList(mock_result_1, mock_result_2, mock_result_3)
+    mock.get_rate_limit.return_value = MockRateLimit(10, 10, "now", 10, 10, "now")
     return mock
 
 
@@ -77,3 +74,23 @@ def test_get_filtered_results_verbose(mock_client, mock_result_1, mock_result_2,
     assert repos == {"org/repo1": [mock_result_2]}
     mock_click.echo.assert_any_call("Skipping result for org/repo1 via Mock")
     mock_click.echo.assert_any_call("Skipping result for org/repo2 via Mock")
+
+
+def test_get_filtered_results_crosses_threshold(mock_client, mock_click):
+    mock_client.get_rate_limit.return_value = MockRateLimit(1, 10, "sometime in the future", 10, 10, "now")
+    mock_filter = Mock()
+    mock_filter.uses_core_api = True
+
+    ghsearch = GHSearch(mock_client, [mock_filter])
+    ghsearch.get_filtered_results(["query", "org:bort"])
+
+    mock_click.confirm.assert_called_once_with(
+        """
+Warning: you are at risk of using more than the remaining 10% of your core api limit.
+Your search yielded 3 results, and each result may trigger up to 1 core api call(s) per result.
+
+Your current usage is 1/10 (resets at sometime in the future)
+
+Do you want to continue?""".strip(),
+        abort=True,
+    )


### PR DESCRIPTION
Before processing the search results, compute the maximum number of core api calls that will be made by the core api filters (`NotArchivedFilter` and `ContentFilter`). Subtract this value from the 'remaining' core api quota, and if the result is less than 10% of the limit then abort.