### PR TITLE
 Improve performance of NotArchivedFilter

### DIFF
--- a/ghsearch/filters.py
+++ b/ghsearch/filters.py
@@ -19,8 +19,13 @@ class ContentFilter(Filter):
 
 
 class NotArchivedFilter(Filter):
+    def __init__(self):
+        self.cache = {}
+
     def __call__(self, result: ContentFile) -> bool:
-        return not result.repository.archived
+        if result.repository.full_name not in self.cache:
+            self.cache[result.repository.full_name] = not result.repository.archived
+        return self.cache[result.repository.full_name]
 
 
 class PathFilter(Filter):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -19,7 +19,9 @@ class MockRateLimit:
         self.search = SimpleNamespace(remaining=search_remaining, limit=search_limit, reset=search_reset)
 
 
-def build_mock_result(repo_full_name: str, path: str, archived: bool = False, decoded_content: bytes = b""):
+def build_mock_content_file(
+    repo_full_name: str = "org/repo", path: str = "path", archived: bool = False, decoded_content: bytes = b""
+):
     mock = Mock(spec=ContentFile)
     mock.repository.full_name = repo_full_name
     mock.repository.archived = archived

--- a/tests/unit/filters_test.py
+++ b/tests/unit/filters_test.py
@@ -1,14 +1,8 @@
-from unittest.mock import Mock
-
 import pytest
-from github.ContentFile import ContentFile
 
 from ghsearch.filters import ContentFilter, NotArchivedFilter, PathFilter
 
-
-@pytest.fixture
-def mock_content_file():
-    return Mock(spec=ContentFile)
+from . import build_mock_content_file
 
 
 @pytest.mark.parametrize(
@@ -20,9 +14,9 @@ def mock_content_file():
         ("other.py", "path/to/file.py", False),
     ],
 )
-def test_build_path_filter(path_matcher, path, expected_result, mock_content_file):
+def test_build_path_filter(path_matcher, path, expected_result):
     path_filter = PathFilter(path_matcher)
-    mock_content_file.path = path
+    mock_content_file = build_mock_content_file(path=path)
 
     assert path_filter(mock_content_file) is expected_result
     assert path_filter.uses_core_api is False
@@ -35,9 +29,9 @@ def test_build_path_filter(path_matcher, path, expected_result, mock_content_fil
         ("another str", b"I'm still looking for this str", False),
     ],
 )
-def test_build_content_filter(content_matcher, content_bytes, expected_result, mock_content_file):
+def test_build_content_filter(content_matcher, content_bytes, expected_result):
     content_filter = ContentFilter(content_matcher)
-    mock_content_file.decoded_content = content_bytes
+    mock_content_file = build_mock_content_file(decoded_content=content_bytes)
 
     assert content_filter(mock_content_file) is expected_result
     assert content_filter.uses_core_api is True
@@ -50,9 +44,9 @@ def test_build_content_filter(content_matcher, content_bytes, expected_result, m
         (True, False),
     ],
 )
-def test_build_not_archived_filter(archived, expected_result, mock_content_file):
+def test_build_not_archived_filter(archived, expected_result):
     not_archived_filter = NotArchivedFilter()
-    mock_content_file.repository.archived = archived
+    mock_content_file = build_mock_content_file(archived=archived)
 
     assert not_archived_filter(mock_content_file) is expected_result
     assert not_archived_filter.uses_core_api is True

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -5,22 +5,22 @@ import pytest
 
 from ghsearch.gh_search import GHSearch
 
-from . import MockPaginatedList, MockRateLimit, build_mock_result
+from . import MockPaginatedList, MockRateLimit, build_mock_content_file
 
 
 @pytest.fixture
 def mock_result_1():
-    return build_mock_result("org/repo1", "1.txt")
+    return build_mock_content_file("org/repo1", "1.txt")
 
 
 @pytest.fixture
 def mock_result_2():
-    return build_mock_result("org/repo1", "2.txt")
+    return build_mock_content_file("org/repo1", "2.txt")
 
 
 @pytest.fixture
 def mock_result_3():
-    return build_mock_result("org/repo2", "3.txt")
+    return build_mock_content_file("org/repo2", "3.txt")
 
 
 @pytest.fixture

--- a/tests/unit/main_test.py
+++ b/tests/unit/main_test.py
@@ -6,7 +6,7 @@ from github import BadCredentialsException, Github, GithubException
 
 from ghsearch.main import run
 
-from . import MockPaginatedList, MockRateLimit, build_mock_result
+from . import MockPaginatedList, MockRateLimit, build_mock_content_file
 
 
 @pytest.fixture(autouse=True)
@@ -19,9 +19,9 @@ def mock_progress_printer():
 def mock_github():
     mock = Mock(spec=Github)
     mock.search_code.return_value = MockPaginatedList(
-        build_mock_result("org/repo1", "README.md", decoded_content=b"special content"),
-        build_mock_result("org/repo1", "file.txt"),
-        build_mock_result("org/repo2", "src/other.py", archived=True),
+        build_mock_content_file("org/repo1", "README.md", decoded_content=b"special content"),
+        build_mock_content_file("org/repo1", "file.txt"),
+        build_mock_content_file("org/repo2", "src/other.py", archived=True),
     )
     mock.get_rate_limit.side_effect = [
         MockRateLimit(45, 50, "soon", 10, 10, "soon"),


### PR DESCRIPTION
Cache the 'archived' result per repo since it makes a core API call each time

- 7d4abcdf8dde36949b51b6eacecc7771ab919383 refactor test utils
- 981e025830502591fcbfc8cfa89d553eaca39cf8 cache results (main functionality change for PR)