### PR TITLE
Limit many core api calls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [report]
 fail_under = 90
+exclude_lines =
+    raise NotImplementedError

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -5,9 +5,9 @@ from github.ContentFile import ContentFile
 
 
 class MockPaginatedList:
-    def __init__(self, *items):
+    def __init__(self, *items, total_count=None):
         self.items = items
-        self.totalCount = len(items)
+        self.totalCount = total_count if total_count else len(items)
 
     def __iter__(self):
         return iter(self.items)


### PR DESCRIPTION
Check if any filters will result in making more than 500 core api calls and check with user if they want to continue

fixes #16