### PR TITLE
Add --repos-with-matches flag

### DIFF
--- a/ghsearch/cli.py
+++ b/ghsearch/cli.py
@@ -32,6 +32,7 @@ def _create_none_value_validator(message):
 @click.option("-p", "--path-filter", help="Exclude results whose path (or part of path) does not match this.")
 @click.option("-c", "--content-filter", help="Exclude results whose content does not match this.")
 @click.option("-a", "--include-archived", help="Include results from archived repos.", default=False, is_flag=True)
+@click.option("-l", "--repos-with-matches", help="Only the names of repos are printed.", default=False, is_flag=True)
 @click.option("-v", "--verbose", help="Verbose output.", default=False, is_flag=True)
 def cli(*args, **kwargs):
     run(*args, **kwargs)

--- a/ghsearch/main.py
+++ b/ghsearch/main.py
@@ -15,6 +15,13 @@ def _sanitize_qualifiers_for_search_url(query: List[str]) -> List[str]:
     return [q for q in query if not (q.startswith("repo:") or q.startswith("org:"))]
 
 
+def _print_repo_names_only(results: Dict[str, List[ContentFile]]) -> None:
+    if len(results) == 0:
+        return
+    for repo in results:
+        click.echo(repo)
+
+
 def _print_results(query: List[str], results: Dict[str, List[ContentFile]]) -> None:
     if len(results) == 0:
         click.echo("No results!")
@@ -51,6 +58,7 @@ def run(
     path_filter: str = "",
     content_filter: str = "",
     include_archived: bool = False,
+    repos_with_matches: bool = False,
     verbose: bool = False,
 ) -> None:
     client = build_client(github_token, github_api_url)
@@ -59,7 +67,11 @@ def run(
         gh_search = GHSearch(client, filters, verbose)
         results = gh_search.get_filtered_results(query)
 
-        _print_results(query, results)
+        if repos_with_matches:
+            _print_repo_names_only(results)
+        else:
+            _print_results(query, results)
+
     except BadCredentialsException as ex:
         raise UsageError(f"Bad Credentials: {ex}", click.get_current_context(silent=True))
     except GithubException as ex:

--- a/ghsearch/terminal.py
+++ b/ghsearch/terminal.py
@@ -1,5 +1,6 @@
 import contextlib
 import re
+import sys
 
 import click
 
@@ -18,14 +19,15 @@ def _term_len(x):
 
 class ProgressPrinter(contextlib.AbstractContextManager):
     def __init__(self, overwrite=True):
-        self.overwrite = overwrite
+        self.overwrite = overwrite and sys.stdout.isatty()
+        self.verbose = not overwrite
         self.last_width = 0
 
     def __enter__(self):
         def printer(message):
             if self.overwrite:
                 self._overwrite_previous_line(message)
-            else:
+            elif self.verbose:
                 click.echo(message)
 
         return printer

--- a/tests/unit/main_test.py
+++ b/tests/unit/main_test.py
@@ -106,10 +106,16 @@ def test_run_path_filter(assert_click_echo_calls):
     )
 
 
-def test_run_no_results(assert_click_echo_calls, mock_github):
+def test_run_repos_with_matches(assert_click_echo_calls):
+    run(["query"], "token", repos_with_matches=True)
+    assert_click_echo_calls(call("org/repo1"))
+
+
+@pytest.mark.parametrize("repos_with_matches, expected_calls", [(False, [call("No results!")]), (True, [])])
+def test_run_no_results(assert_click_echo_calls, mock_github, repos_with_matches, expected_calls):
     mock_github.search_code.return_value = MockPaginatedList()
-    run(["query"], "token")
-    assert_click_echo_calls(call("No results!"))
+    run(["query"], "token", repos_with_matches=repos_with_matches)
+    assert_click_echo_calls(*expected_calls)
 
 
 def test_run_when_raises_github_exception_422(mock_github):

--- a/tests/unit/terminal_test.py
+++ b/tests/unit/terminal_test.py
@@ -1,22 +1,36 @@
-from unittest.mock import call
+from unittest.mock import call, patch
+
+import pytest
 
 from ghsearch.terminal import ProgressPrinter
 
 
-def test_progress_printer(assert_click_echo_calls):
+@pytest.mark.parametrize(
+    "overwrite, isatty, expected_calls",
+    [
+        # overwrite = True, isatty = True
+        (
+            True,
+            True,
+            [
+                call("\r\033[?25lHello!", nl=False),
+                call("\r\033[?25l      ", nl=False),
+                call("\r\033[?25h", nl=False),
+            ],
+        ),
+        # overwrite = False, isatty = True
+        (False, True, [call("Hello!")]),
+        # overwrite = True, isatty = False
+        (True, False, []),
+        # overwrite = False, isatty = False
+        (False, False, [call("Hello!")]),
+    ],
+)
+def test_progress_printer(assert_click_echo_calls, overwrite, isatty, expected_calls):
+    with patch("ghsearch.terminal.sys") as mock_sys:
+        mock_sys.stdout.isatty.return_value = isatty
 
-    with ProgressPrinter() as printer:
-        printer("Hello!")
+        with ProgressPrinter(overwrite=overwrite) as printer:
+            printer("Hello!")
 
-    assert_click_echo_calls(
-        call("\r\033[?25lHello!", nl=False),
-        call("\r\033[?25l      ", nl=False),
-        call("\r\033[?25h", nl=False),
-    )
-
-
-def test_progress_printer_verbose(assert_click_echo_calls):
-    with ProgressPrinter(overwrite=False) as printer:
-        printer("Hello!")
-
-    assert_click_echo_calls(call("Hello!"))
+    assert_click_echo_calls(*expected_calls)


### PR DESCRIPTION
Closes #29 

- Add `--repos-with-matches` flag (shortcut `-l`): only prints names of repos containing results
- Disable progress printer if stdout is a tty
