### PR TITLE
Move regex content filtering under separate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ _Note that `repo:` is a search qualifier natively supported by the GitHub Search
 
 - `-a`/`--include-archived`: include results from archived repos (default behaviour is to exclude results from archived repositories).
 - `-p TEXT`/`--path-filter TEXT`: similar to the `path:` search qualifier, but a bit more flexible as it does a string match on the path (rather than relying on GitHub's indexed path components). For example `-p cat` will show matches against a file called `mycat.json` whereas `path:cat` will not.
-- `-c TEXT`/`--content-filter TEXT`: include results with content that yields a match against a regular expression (`TEXT`). A lot more flexible than specifying an additional search term in the search query, which relies on how GitHub has indexed a file for searching.
+- `-c TEXT`/`--content-filter TEXT`: include results with content that matches against a string (`TEXT`). A lot more flexible than specifying an additional search term in the search query, which relies on how GitHub has indexed a file for searching.
+- `-e TEXT`/`--regex-content-filter TEXT`: Just like `--content-filter` but matches against a regular expression (`TEXT`).
 - `-l` / `--repos-with-matches`: only prints the names of the repos with matching results
 - `-v` / `--verbose`: verbose output, print information about the repos being scanned and ignored via filters
 

--- a/ghsearch/cli.py
+++ b/ghsearch/cli.py
@@ -31,6 +31,7 @@ def _create_none_value_validator(message):
 )
 @click.option("-p", "--path-filter", help="Exclude results whose path (or part of path) does not match this.")
 @click.option("-c", "--content-filter", help="Exclude results whose content does not match this.")
+@click.option("-e", "--regex-content-filter", help="Exclude results whose content does not match this regex.")
 @click.option("-a", "--include-archived", help="Include results from archived repos.", default=False, is_flag=True)
 @click.option("-l", "--repos-with-matches", help="Only the names of repos are printed.", default=False, is_flag=True)
 @click.option("-v", "--verbose", help="Verbose output.", default=False, is_flag=True)

--- a/ghsearch/main.py
+++ b/ghsearch/main.py
@@ -7,7 +7,7 @@ from github.ContentFile import ContentFile
 from github.GithubException import BadCredentialsException, GithubException
 
 from ghsearch.client import build_client
-from ghsearch.filters import ContentFilter, Filter, FilterException, NotArchivedFilter, PathFilter
+from ghsearch.filters import ContentFilter, Filter, FilterException, NotArchivedFilter, PathFilter, RegexContentFilter
 from ghsearch.gh_search import GHSearch
 
 
@@ -42,7 +42,9 @@ def _print_results(query: List[str], results: Dict[str, List[ContentFile]]) -> N
             click.echo(f"\t- {result.path}")
 
 
-def _build_filters(path_filter: str = None, include_archived: bool = True, content_filter: str = None) -> List[Filter]:
+def _build_filters(
+    path_filter: str = None, include_archived: bool = True, content_filter: str = None, regex_content_filter: str = None
+) -> List[Filter]:
     filters: List[Filter] = []
     if path_filter:
         filters.append(PathFilter(path_filter))
@@ -50,6 +52,8 @@ def _build_filters(path_filter: str = None, include_archived: bool = True, conte
         filters.append(NotArchivedFilter())
     if content_filter:
         filters.append(ContentFilter(content_filter))
+    if regex_content_filter:
+        filters.append(RegexContentFilter(regex_content_filter))
     return filters
 
 
@@ -57,8 +61,9 @@ def run(
     query: List[str],
     github_token: str,
     github_api_url: str = None,
-    path_filter: str = "",
-    content_filter: str = "",
+    path_filter: str = None,
+    content_filter: str = None,
+    regex_content_filter: str = None,
     include_archived: bool = False,
     repos_with_matches: bool = False,
     verbose: bool = False,
@@ -66,7 +71,7 @@ def run(
     client = build_client(github_token, github_api_url)
 
     try:
-        filters = _build_filters(path_filter, include_archived, content_filter)
+        filters = _build_filters(path_filter, include_archived, content_filter, regex_content_filter)
     except FilterException as ex:
         raise UsageError(str(ex), click.get_current_context(silent=True))
 

--- a/tests/unit/main_test.py
+++ b/tests/unit/main_test.py
@@ -97,12 +97,21 @@ def test_run_content_filter(assert_click_echo_calls):
     )
 
 
-def test_run_content_filter_bad_regex():
+def test_run_regex_content_filter(assert_click_echo_calls):
+    run(["query"], "token", regex_content_filter="special\\scontent")
+    assert_click_echo_calls(
+        call("Results:"),
+        call(" 1 - org/repo1: https://www.github.com/org/repo1/search?utf8=✓&q=query"),
+        call("\t- README.md"),
+    )
+
+
+def test_run_regex_content_filter_bad_regex():
     with pytest.raises(
         click.UsageError,
         match="Failed to compile regular expression from '\\[': unterminated character set at position 0",
     ):
-        run(["query"], "token", content_filter="[")
+        run(["query"], "token", regex_content_filter="[")
 
 
 def test_run_path_filter(assert_click_echo_calls):


### PR DESCRIPTION
Added `--regex-content-filter` for filtering based on a regular
expression. Restored original behaviour of `--content-filter` to _not_
compile a regex and match against it (but just match against the string
directly).