### PR TITLE
Handle cases where no rate limiting is used

### DIFF
--- a/ghsearch/gh_search.py
+++ b/ghsearch/gh_search.py
@@ -40,16 +40,11 @@ Do you want to continue?""".strip(),
     )
 
 
-def _echo_rate_limits(rate_limit: RateLimit | None) -> None:
-    if rate_limit is None:
-        click.echo("(Rate limiting is disabled)")
-    else:
-        core = rate_limit.core
-        search = rate_limit.search
-        click.echo(
-            f"Core rate limit: {core.remaining}/{core.limit} (resets {core.reset}), "
-            f"Search rate limit: {search.remaining}/{search.limit} (resets {search.reset})"
-        )
+def _echo_rate_limits(rate_limit: RateLimit) -> None:
+    click.echo(
+        f"Core rate limit: {rate_limit.core.remaining}/{rate_limit.core.limit} (resets {rate_limit.core.reset}), "
+        f"Search rate limit: {rate_limit.search.remaining}/{rate_limit.search.limit} (resets {rate_limit.search.reset})"
+    )
 
 
 class GHSearch:
@@ -70,7 +65,7 @@ class GHSearch:
     def get_filtered_results(self, query: List[str]) -> List[ContentFile]:
         rate_limit = self.get_rate_limit()
 
-        if self.verbose:
+        if rate_limit and self.verbose:
             _echo_rate_limits(rate_limit)
 
         results = self.client.search_code(query=" ".join(query))
@@ -92,8 +87,8 @@ class GHSearch:
                     elif self.verbose:
                         click.echo(f"Skipping result for {result.repository.full_name} via {exclude_reason}")
 
-        if self.verbose:
-            rate_limit = self.get_rate_limit()
+        rate_limit = self.get_rate_limit()
+        if rate_limit and self.verbose:
             _echo_rate_limits(rate_limit)
 
         return filtered_results

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -129,13 +129,13 @@ Do you want to continue?""".strip(),
     )
 
 
-def test_get_filtered_results_rate_limiting_disabled(mock_client, mock_click):
+def test_get_filtered_results_rate_limiting_disabled(mock_client):
     mock_client.get_rate_limit.side_effect = github.GithubException(404, "Not Found")
-    mock_client.search_code.return_value = MockPaginatedList(*[], total_count=0)
     mock_filter = Mock()
     mock_filter.uses_core_api = True
 
-    ghsearch = GHSearch(mock_client, [mock_filter], True)
+    ghsearch = GHSearch(mock_client, [])
     ghsearch.get_filtered_results(["query", "org:bort"])
 
-    mock_click.echo.assert_any_call("(Rate limiting is disabled)")
+    # ensure get_rate_limit was called (and the side_effect above handled)
+    mock_client.get_rate_limit.assert_called()

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -128,6 +128,7 @@ Do you want to continue?""".strip(),
         abort=True,
     )
 
+
 def test_get_filtered_results_rate_limiting_disabled(mock_client, mock_click):
     mock_client.get_rate_limit.side_effect = github.GithubException(404, "Not Found")
     mock_client.search_code.return_value = MockPaginatedList(*[], total_count=0)

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -127,3 +127,14 @@ Your current core api usage is 10000/10000 (resets sometime in the future)
 Do you want to continue?""".strip(),
         abort=True,
     )
+
+def test_get_filtered_results_rate_limiting_disabled(mock_client, mock_click):
+    mock_client.get_rate_limit.side_effect = github.GithubException(404, "Not Found")
+    mock_client.search_code.return_value = MockPaginatedList(*[], total_count=0)
+    mock_filter = Mock()
+    mock_filter.uses_core_api = True
+
+    ghsearch = GHSearch(mock_client, [mock_filter], True)
+    ghsearch.get_filtered_results(["query", "org:bort"])
+
+    mock_click.echo.assert_any_call("(Rate limiting is disabled)")


### PR DESCRIPTION
In this case I catch the exception that is thrown and create a rate limit object with significantly high (1 billion) remaining requests. The rest of the code operates normally. 