### PR TITLE
fix: print confirmation prompts to stderr

### DIFF
--- a/ghsearch/gh_search.py
+++ b/ghsearch/gh_search.py
@@ -24,6 +24,7 @@ Your current core api usage is {core_rate.remaining}/{core_rate.limit} (resets {
 
 Do you want to continue?""".strip(),
         abort=True,
+        err=True,
     )
 
 
@@ -37,6 +38,7 @@ Your current core api usage is {core_rate.remaining}/{core_rate.limit} (resets {
 
 Do you want to continue?""".strip(),
         abort=True,
+        err=True,
     )
 
 

--- a/tests/unit/gh_search_test.py
+++ b/tests/unit/gh_search_test.py
@@ -105,6 +105,7 @@ Your current core api usage is 1/10 (resets sometime in the future)
 
 Do you want to continue?""".strip(),
         abort=True,
+        err=True,
     )
 
 
@@ -126,6 +127,7 @@ Your current core api usage is 10000/10000 (resets sometime in the future)
 
 Do you want to continue?""".strip(),
         abort=True,
+        err=True,
     )
 
 


### PR DESCRIPTION
This makes it easier to pipe the output to a file.  For example:

```sh
gh-search --regex-content-filter "live_[0-9]{6,10}_" twitch app rtmp >twitch-keys.txt
```